### PR TITLE
module source should be relative URI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "service_principal" {
-    source = "service_principal"
+    source = "./service_principal"
     sp_name             = "${local.cluster_name}"
 }
 


### PR DESCRIPTION
https://www.terraform.io/docs/modules/index.html

> If the root module includes calls to nested modules, they should use relative paths like `./modules/consul-cluster` so that Terraform will consider them to be part of the same repository or package, rather than downloading them again separately.